### PR TITLE
fix(health): allow public access to health check endpoint and document API (#59)

### DIFF
--- a/backend/src/main/java/com/servicehub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/servicehub/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login", "/register", "/logout", "/assets/**", "/error").permitAll()
                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/health").permitAll()
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/backend/src/main/java/com/servicehub/controller/api/HealthController.java
+++ b/backend/src/main/java/com/servicehub/controller/api/HealthController.java
@@ -2,6 +2,9 @@ package com.servicehub.controller.api;
 
 import com.servicehub.dto.HealthResponse;
 import com.servicehub.service.HealthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/health")
 @RequiredArgsConstructor
+@Tag(name = "Health", description = "Application health check — no authentication required")
 public class HealthController {
 
     private final HealthService healthService;
 
+    @Operation(summary = "Check application health")
+    @ApiResponse(responseCode = "200", description = "Application is up")
     @GetMapping
     public ResponseEntity<HealthResponse> health() {
         return ResponseEntity.ok(healthService.getHealth());


### PR DESCRIPTION
## Changes made

### SecurityConfig
- Added `.requestMatchers("/api/health").permitAll()` so the health endpoint is accessible without authentication.

### HealthController
- Added Swagger annotations:
  - `@Tag`
  - `@Operation`
  - `@ApiResponse`