### PR TITLE
fix(auth): enhance JWT authentication to return JSON responses for unauthorized API requests (#60)

### DIFF
--- a/backend/src/main/java/com/servicehub/config/JwtAuthFilter.java
+++ b/backend/src/main/java/com/servicehub/config/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package com.servicehub.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.servicehub.repository.TokenBlacklistRepository;
 import com.servicehub.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
@@ -16,11 +17,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final JwtService jwtService;
     private final CustomUserDetailsService userDetailsService;
@@ -35,10 +40,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             try {
-                // Reject blacklisted (logged-out) tokens immediately
                 if (tokenBlacklistRepository.existsByToken(token)) {
-                    SecurityContextHolder.clearContext();
-                    filterChain.doFilter(request, response);
+                    rejectWithJson(request, response, "Token has been revoked. Please log in again.");
                     return;
                 }
 
@@ -50,13 +53,44 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                             userDetails, null, userDetails.getAuthorities());
                     authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authToken);
+                } else {
+                    // Token present but invalid (expired, bad signature, etc.)
+                    SecurityContextHolder.clearContext();
+                    if (isApiRequest(request)) {
+                        rejectWithJson(request, response, "Token is invalid or has expired. Please log in again.");
+                        return;
+                    }
                 }
-            } catch (Exception ignored) {
+            } catch (Exception e) {
                 SecurityContextHolder.clearContext();
+                if (isApiRequest(request)) {
+                    rejectWithJson(request, response, "Token is invalid or has expired. Please log in again.");
+                    return;
+                }
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isApiRequest(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/api/");
+    }
+
+    private void rejectWithJson(HttpServletRequest request,
+                                HttpServletResponse response,
+                                String message) throws IOException {
+        SecurityContextHolder.clearContext();
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(MAPPER.writeValueAsString(Map.of(
+            "status", 401,
+            "error", "Unauthorized",
+            "message", message,
+            "path", request.getRequestURI(),
+            "timestamp", LocalDateTime.now().toString()
+        )));
     }
 
     private String extractToken(HttpServletRequest request) {

--- a/backend/src/main/java/com/servicehub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/servicehub/config/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.servicehub.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.servicehub.service.CustomUserDetailsService;
 import com.servicehub.service.OAuth2UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,8 +18,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
@@ -41,6 +47,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login", "/register", "/logout", "/assets/**", "/error").permitAll()
                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/health").permitAll()
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
@@ -50,8 +57,15 @@ public class SecurityConfig {
                 .requestMatchers("/dashboard/user").hasAnyRole("ADMIN", "AGENT", "USER")
                 .requestMatchers("/requests/assigned", "/requests/open").hasAnyRole("ADMIN", "AGENT")
                 .requestMatchers("/requests/**").hasAnyRole("ADMIN", "AGENT", "USER")
-                .requestMatchers("/api/service-requests/**", "/api/requests/**").authenticated()
+                .requestMatchers("/api/**").authenticated()
                 .anyRequest().authenticated()
+            )
+            // For API paths: return 401 JSON — never redirect to login HTML
+            .exceptionHandling(ex -> ex
+                .defaultAuthenticationEntryPointFor(
+                    apiAuthenticationEntryPoint(),
+                    req -> req.getRequestURI().startsWith("/api/")
+                )
             )
             .formLogin(form -> form
                 .loginPage("/login")
@@ -67,12 +81,28 @@ public class SecurityConfig {
                 .defaultSuccessUrl("/oauth2/success", true)
                 .failureUrl("/login?error")
             )
-            // Logout is handled entirely by AuthViewController GET /logout
             .logout(AbstractHttpConfigurer::disable)
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
             .authenticationProvider(authenticationProvider());
 
         return http.build();
+    }
+
+    // Returns a JSON 401 body instead of a 302 redirect to /login
+    @Bean
+    public AuthenticationEntryPoint apiAuthenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            String body = new ObjectMapper().writeValueAsString(Map.of(
+                "status", 401,
+                "error", "Unauthorized",
+                "message", "Authentication required. Please provide a valid Bearer token.",
+                "timestamp", LocalDateTime.now().toString()
+            ));
+            response.getWriter().write(body);
+        };
     }
 
     // ── Auth infrastructure beans ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR fixes incorrect authentication behavior for API requests by ensuring unauthorized or invalid-token access returns a proper `401 Unauthorized` JSON response instead of redirecting to the login page or allowing the request to continue.

## Issues fixed

### 1. HTML returned instead of JSON
For unauthenticated requests to `/api/**`, `SecurityConfig` did not define an `AuthenticationEntryPoint`. As a result, Spring Security fell back to its default behavior and redirected the client to `/login`, which returned the Thymeleaf login page HTML instead of a JSON error response.

**Fix**
- Added `.exceptionHandling()`
- Configured `defaultAuthenticationEntryPointFor(...)` for `/api/**`
- Used a matcher and custom response handler to return a structured `401 Unauthorized` JSON response directly

### 2. Invalid token returned `200 OK`
In `JwtAuthFilter`, invalid JWTs were being swallowed by `catch (Exception ignored)`. When token parsing or validation failed due to expiration, malformed structure, or invalid signature, the filter cleared the context and still continued the filter chain. This allowed the request to proceed unauthenticated and potentially return `200 OK`.

**Fix**
- Updated the catch block to detect API requests using `isApiRequest()`
- Added `rejectWithJson()` to write a `401 Unauthorized` JSON response directly
- Prevented the filter chain from continuing for `/api/**` requests with invalid tokens

## Result
API requests now behave correctly:
- missing authentication returns `401` JSON
- invalid or malformed tokens return `401` JSON
- clients no longer receive HTML login pages for API auth failures