### PR TITLE
fix(auth): restrict public access to specific authentication endpoints (#68)

### DIFF
--- a/backend/src/main/java/com/servicehub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/servicehub/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .requestMatchers("/login", "/register", "/logout", "/assets/**", "/error").permitAll()
                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/health").permitAll()
-                .requestMatchers("/api/v1/auth/**").permitAll()
+                .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
                 .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .requestMatchers("/agent/**").hasAnyRole("ADMIN", "AGENT")


### PR DESCRIPTION
## Summary
This PR fixes the logout endpoint security configuration so that `/api/v1/auth/logout` is no longer publicly accessible.

## Root cause
The pattern `/api/v1/auth/**` was configured as `permitAll()`, which matched all auth sub-paths, including `/logout`.

Because of that:
- Spring Security treated `/api/v1/auth/logout` as public
- authentication was never enforced for logout
- the request could pass through regardless of whether a token was present

## Fix
Updated `SecurityConfig` to permit only the intended public auth endpoints.

### Before
```java
.requestMatchers("/api/v1/auth/**").permitAll()
````

### After

```java
.requestMatchers(
    "/api/v1/auth/register",
    "/api/v1/auth/login",
    "/api/v1/auth/refresh"
).permitAll()
```

`/api/v1/auth/logout` is intentionally no longer included in `permitAll()`.

## Result

`/api/v1/auth/logout` now falls through to:

```java
.requestMatchers("/api/**").authenticated()
```

This restores the expected behavior:

* **No token** → Spring Security invokes the API authentication entry point → `401 Unauthorized` JSON
* **Blacklisted token** → `JwtAuthFilter` intercepts and returns `401 Unauthorized` JSON
* **Valid token** → authentication succeeds → logout completes successfully → `204 No Content`

## Impact

This change closes a security gap by ensuring logout is protected and behaves consistently with the rest of the secured API.

<img width="1100" height="374" alt="image" src="https://github.com/user-attachments/assets/259985f1-9475-429f-acdd-6c0a16a25c43" />

