### PR TITLE
ci: update image tagging in the CI merge workflow (#23)

### DIFF
--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -21,7 +21,7 @@ jobs:
             run_tests: true
             build_image: true
             push_image: true
-            run_data_tests: false
+            run_data_tests: true
             run_checkov: true
             deploy_dags: false
         secrets: inherit

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -192,7 +192,6 @@ jobs:
                   context: backend
                   file: backend/Dockerfile
                   tags: |
-                      servicehub:${{ steps.meta.outputs.image_tag }}
                       ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.meta.outputs.image_tag }}
                       ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:latest
                   push: ${{ inputs.push_image }}


### PR DESCRIPTION
This pull request updates the CI workflows to improve test coverage and refines Docker image tagging in the build process. The most important changes are:

**CI Workflow Improvements:**

* Enabled data tests to run during the merge workflow by setting `run_data_tests` to `true` in `.github/workflows/ci-merge.yml`.

**Docker Image Tagging:**

* Removed the local `servicehub:${{ steps.meta.outputs.image_tag }}` tag from the Docker image build process in `.github/workflows/ci-reusable.yml`, ensuring only ECR repository tags are used.