### PR TITLE
chore: exclude the venv directory from flake8 linting in the CI workf…

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -119,9 +119,9 @@ jobs:
               run: |
                   source .venv/bin/activate
                   # stop the build if there are Python syntax errors or undefined names
-                  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+                  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.venv
                   # exit-zero treats all errors as warnings
-                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.venv
 
             - name: Run tests
               working-directory: data-engineering


### PR DESCRIPTION
This pull request updates the CI workflow to improve Python linting by excluding the `.venv` directory from `flake8` checks. This prevents unnecessary linting of virtual environment files, which can reduce noise and speed up the linting process.

- **CI workflow improvements:**
  * Updated `flake8` commands in `.github/workflows/ci-reusable.yml` to add the `--exclude=.venv` flag, ensuring that files in the `.venv` directory are not checked during linting.…low (#23)