### PR TITLE
chore: disable Trivy scans in CI workflows (#23)

### DIFF
--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -23,7 +23,7 @@ jobs:
             push_image: false
             run_data_tests: true
             run_checkov: true
-            run_trivy: true
+            run_trivy: false
             run_sbom: true
             deploy_dags: false
         secrets: inherit

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,6 +26,6 @@ jobs:
             build_image: false
             run_data_tests: true
             run_checkov: true            
-            run_trivy: true
+            run_trivy: false
             run_sbom: true
         secrets: inherit


### PR DESCRIPTION
This pull request updates the CI workflow configuration to temporarily disable Trivy security scans in both the pull request and merge workflows. All other checks remain enabled.

CI Workflow configuration:

* Disabled the Trivy vulnerability scanner by setting `run_trivy: false` in both `.github/workflows/ci-pr.yml` and `.github/workflows/ci-merge.yml`. [[1]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L29-R29) [[2]](diffhunk://#diff-a5d19118b913bff0f8969d4c2f2f113389cd8406d98028a2f72e7a9ea5ec5c70L26-R26)