### PR TITLE
feat: enable image push in CI workflow (#23)

### DIFF
--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -20,7 +20,7 @@ jobs:
             run_checkstyle: true
             run_tests: true
             build_image: true
-            push_image: false
+            push_image: true
             run_data_tests: true
             run_checkov: true
             run_trivy: false


### PR DESCRIPTION
This pull request updates the CI workflow to push built images as part of the merge process. The most important change is:

CI/CD workflow update:

* Changed the `push_image` step in `.github/workflows/ci-merge.yml` to `true`, ensuring that built images are now pushed during the merge workflow.