### PR TITLE
refactor(backend): decouple service request SLA assignment

### DIFF
--- a/backend/src/main/java/com/servicehub/event/ServiceRequestCreatedEvent.java
+++ b/backend/src/main/java/com/servicehub/event/ServiceRequestCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.servicehub.event;
+
+import com.servicehub.model.ServiceRequest;
+
+public record ServiceRequestCreatedEvent(ServiceRequest request) {
+}

--- a/backend/src/main/java/com/servicehub/mapper/ServiceRequestMapper.java
+++ b/backend/src/main/java/com/servicehub/mapper/ServiceRequestMapper.java
@@ -12,6 +12,11 @@ import java.util.UUID;
 @Mapper(componentModel = "spring")
 public interface ServiceRequestMapper {
 
+    @Mapping(target = "departmentId", source = "department.id")
+    @Mapping(target = "assignedToId", source = "assignedTo.id")
+    @Mapping(target = "requesterId", source = "requester.id")
+    ServiceRequestResponse toResponse(ServiceRequest serviceRequest);
+
     ServiceRequest toEntity(ServiceRequestResponse serviceRequestResponse);
 
     @Mapping(target = "requesterId", source = "requesterId")

--- a/backend/src/main/java/com/servicehub/service/SlaService.java
+++ b/backend/src/main/java/com/servicehub/service/SlaService.java
@@ -1,8 +1,7 @@
 package com.servicehub.service;
 
-import java.time.OffsetDateTime;
-
 import com.servicehub.model.ServiceRequest;
+import java.time.OffsetDateTime;
 
 public interface SlaService {
 

--- a/backend/src/main/java/com/servicehub/service/impl/ServiceRequestServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/ServiceRequestServiceImpl.java
@@ -2,24 +2,23 @@ package com.servicehub.service.impl;
 
 import com.servicehub.dto.ServiceRequestResponse;
 import com.servicehub.dto.ServiceRequestUpsertRequest;
+import com.servicehub.event.ServiceRequestCreatedEvent;
+import com.servicehub.mapper.ServiceRequestMapper;
 import com.servicehub.model.Department;
 import com.servicehub.model.ServiceRequest;
-import com.servicehub.model.SlaPolicy;
 import com.servicehub.model.User;
 import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.exception.AccessDeniedException;
 import com.servicehub.exception.ResourceNotFoundException;
 import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.ServiceRequestRepository;
-import com.servicehub.repository.SlaPolicyRepository;
 import com.servicehub.repository.UserRepository;
 import com.servicehub.service.ServiceRequestService;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +31,8 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
     private final ServiceRequestRepository serviceRequestRepository;
     private final DepartmentRepository departmentRepository;
     private final UserRepository userRepository;
-    private final SlaPolicyRepository slaPolicyRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ServiceRequestMapper serviceRequestMapper;
 
     @Override
     @Transactional
@@ -48,18 +48,16 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
 
         Department department = resolveDepartment(request.getCategory(), request.getDepartmentId());
         serviceRequest.setDepartment(department);
-        serviceRequest.setSlaDeadline(resolveSlaDeadline(request.getCategory(), request.getPriority()));
-        handleStatusChangeMetadata(serviceRequest, null, serviceRequest.getStatus());
-        updateSlaBreachedFlag(serviceRequest);
-
-        return toResponse(serviceRequestRepository.save(serviceRequest));
+        ServiceRequest savedRequest = serviceRequestRepository.save(serviceRequest);
+        eventPublisher.publishEvent(new ServiceRequestCreatedEvent(savedRequest));
+        return serviceRequestMapper.toResponse(savedRequest);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<ServiceRequestResponse> findAll() {
         return serviceRequestRepository.findAll().stream()
-                .map(this::toResponse)
+                .map(serviceRequestMapper::toResponse)
                 .toList();
     }
 
@@ -67,7 +65,7 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
         return serviceRequestRepository.findAllByRequester(user).stream()
                 .sorted(Comparator.comparing(ServiceRequest::getCreatedAt,
                         Comparator.nullsLast(Comparator.reverseOrder())))
-                .map(this::toResponse)
+                .map(serviceRequestMapper::toResponse)
                 .toList();
     }
 
@@ -82,7 +80,7 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
     @Override
     @Transactional(readOnly = true)
     public ServiceRequestResponse findById(UUID id) {
-        return toResponse(getRequestOrThrow(id));
+        return serviceRequestMapper.toResponse(getRequestOrThrow(id));
     }
 
     @Override
@@ -92,15 +90,13 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
                 .orElseThrow(() -> new ResourceNotFoundException("User"));
         ServiceRequest request = serviceRequestRepository.findByIdAndRequester(id, user)
                 .orElseThrow(AccessDeniedException::new);
-        return toResponse(request);
+        return serviceRequestMapper.toResponse(request);
     }
 
     @Override
     @Transactional
     public ServiceRequestResponse update(UUID id, ServiceRequestUpsertRequest request) {
         ServiceRequest existing = getRequestOrThrow(id);
-        RequestStatus oldStatus = existing.getStatus();
-
         if (request.getTitle() != null) {
             if (request.getTitle().isBlank()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title must not be blank");
@@ -138,17 +134,15 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
             existing.setDepartment(department);
         }
 
-        if (categoryChanged || priorityChanged) {
-            existing.setSlaDeadline(resolveSlaDeadline(existing.getCategory(), existing.getPriority()));
-        }
-
         if (request.getStatus() != null) {
             existing.setStatus(request.getStatus());
-            handleStatusChangeMetadata(existing, oldStatus, request.getStatus());
         }
 
-        updateSlaBreachedFlag(existing);
-        return toResponse(serviceRequestRepository.save(existing));
+        ServiceRequest savedRequest = serviceRequestRepository.save(existing);
+        if (categoryChanged || priorityChanged) {
+            eventPublisher.publishEvent(new ServiceRequestCreatedEvent(savedRequest));
+        }
+        return serviceRequestMapper.toResponse(savedRequest);
     }
 
     @Override
@@ -183,62 +177,4 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
         return departmentRepository.findByCategory(category).orElse(null);
     }
 
-    private OffsetDateTime resolveSlaDeadline(
-            com.servicehub.model.enums.RequestCategory category,
-            com.servicehub.model.enums.RequestPriority priority) {
-        return slaPolicyRepository.findByCategoryAndPriority(category, priority)
-                .map(SlaPolicy::getResolutionTimeHours)
-                .map(hours -> OffsetDateTime.now(ZoneOffset.UTC).plusHours(hours))
-                .orElse(null);
-    }
-
-    private void handleStatusChangeMetadata(
-            ServiceRequest serviceRequest, RequestStatus oldStatus, RequestStatus newStatus) {
-        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-
-        if (serviceRequest.getFirstResponseAt() == null
-                && newStatus != null
-                && newStatus != RequestStatus.OPEN
-                && oldStatus != newStatus) {
-            serviceRequest.setFirstResponseAt(now);
-        }
-
-        if (newStatus == RequestStatus.RESOLVED && serviceRequest.getResolvedAt() == null) {
-            serviceRequest.setResolvedAt(now);
-        }
-
-        if (newStatus == RequestStatus.CLOSED && serviceRequest.getClosedAt() == null) {
-            serviceRequest.setClosedAt(now);
-        }
-    }
-
-    private void updateSlaBreachedFlag(ServiceRequest serviceRequest) {
-        boolean isResolvedOrClosed = serviceRequest.getStatus() == RequestStatus.RESOLVED
-                || serviceRequest.getStatus() == RequestStatus.CLOSED;
-        boolean breached = serviceRequest.getSlaDeadline() != null
-                && OffsetDateTime.now(ZoneOffset.UTC).isAfter(serviceRequest.getSlaDeadline())
-                && !isResolvedOrClosed;
-        serviceRequest.setIsSlaBreached(breached);
-    }
-
-    private ServiceRequestResponse toResponse(ServiceRequest serviceRequest) {
-        return ServiceRequestResponse.builder()
-                .id(serviceRequest.getId())
-                .title(serviceRequest.getTitle())
-                .description(serviceRequest.getDescription())
-                .category(serviceRequest.getCategory())
-                .priority(serviceRequest.getPriority())
-                .status(serviceRequest.getStatus())
-                .departmentId(serviceRequest.getDepartment() == null ? null : serviceRequest.getDepartment().getId())
-                .assignedToId(serviceRequest.getAssignedTo() == null ? null : serviceRequest.getAssignedTo().getId())
-                .requesterId(serviceRequest.getRequester() == null ? null : serviceRequest.getRequester().getId())
-                .slaDeadline(serviceRequest.getSlaDeadline())
-                .firstResponseAt(serviceRequest.getFirstResponseAt())
-                .resolvedAt(serviceRequest.getResolvedAt())
-                .closedAt(serviceRequest.getClosedAt())
-                .isSlaBreached(serviceRequest.getIsSlaBreached())
-                .createdAt(serviceRequest.getCreatedAt())
-                .updatedAt(serviceRequest.getUpdatedAt())
-                .build();
-    }
 }

--- a/backend/src/main/java/com/servicehub/service/impl/SlaServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/SlaServiceImpl.java
@@ -1,10 +1,12 @@
 package com.servicehub.service.impl;
 
+import com.servicehub.event.ServiceRequestCreatedEvent;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,11 @@ public class SlaServiceImpl implements SlaService {
     private final SlaPolicyRepository slaPolicyRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final WorkingHoursCalculator workingHoursCalculator;
+
+    @EventListener
+    public void handleServiceRequestCreated(ServiceRequestCreatedEvent event) {
+        calculateAndSetSlaDeadline(event.request());
+    }
 
     @Override
     @Transactional

--- a/backend/src/test/java/com/servicehub/service/impl/ServiceRequestServiceImplTest.java
+++ b/backend/src/test/java/com/servicehub/service/impl/ServiceRequestServiceImplTest.java
@@ -6,25 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.servicehub.dto.ServiceRequestResponse;
 import com.servicehub.dto.ServiceRequestUpsertRequest;
+import com.servicehub.event.ServiceRequestCreatedEvent;
+import com.servicehub.mapper.ServiceRequestMapper;
 import com.servicehub.model.Department;
 import com.servicehub.model.ServiceRequest;
-import com.servicehub.model.SlaPolicy;
 import com.servicehub.model.User;
 import com.servicehub.model.enums.RequestCategory;
 import com.servicehub.model.enums.RequestPriority;
 import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.ServiceRequestRepository;
-import com.servicehub.repository.SlaPolicyRepository;
 import com.servicehub.repository.UserRepository;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -51,24 +51,26 @@ class ServiceRequestServiceImplTest {
     private UserRepository userRepository;
 
     @Mock
-    private SlaPolicyRepository slaPolicyRepository;
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private ServiceRequestMapper serviceRequestMapper;
 
     private ServiceRequestServiceImpl serviceRequestService;
 
     @BeforeEach
     void setUp() {
         serviceRequestService = new ServiceRequestServiceImpl(
-                serviceRequestRepository, departmentRepository, userRepository, slaPolicyRepository);
+                serviceRequestRepository, departmentRepository, userRepository, eventPublisher, serviceRequestMapper);
     }
 
     @Test
-    @DisplayName("create: builds request, auto-routes department, and computes SLA deadline")
-    void createShouldBuildAndPersistWithAutoRoutedDepartmentAndSlaDeadline() {
+    @DisplayName("create: builds request, auto-routes department, and publishes SLA event")
+    void createShouldBuildAndPersistWithAutoRoutedDepartmentAndPublishSlaEvent() {
         UUID requesterId = UUID.randomUUID();
         UUID departmentId = UUID.randomUUID();
         User requester = user(requesterId);
         Department department = department(departmentId, RequestCategory.IT_SUPPORT);
-        SlaPolicy slaPolicy = slaPolicy(RequestCategory.IT_SUPPORT, RequestPriority.HIGH);
 
         ServiceRequestUpsertRequest request = new ServiceRequestUpsertRequest();
         request.setTitle("  Laptop issue  ");
@@ -79,10 +81,10 @@ class ServiceRequestServiceImplTest {
 
         when(userRepository.findById(requesterId)).thenReturn(Optional.of(requester));
         when(departmentRepository.findByCategory(RequestCategory.IT_SUPPORT)).thenReturn(Optional.of(department));
-        when(slaPolicyRepository.findByCategoryAndPriority(RequestCategory.IT_SUPPORT, RequestPriority.HIGH))
-                .thenReturn(Optional.of(slaPolicy));
         when(serviceRequestRepository.save(any(ServiceRequest.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        when(serviceRequestMapper.toResponse(any(ServiceRequest.class)))
+                .thenAnswer(invocation -> toResponse(invocation.getArgument(0)));
 
         ServiceRequestResponse response = serviceRequestService.create(request);
 
@@ -90,8 +92,10 @@ class ServiceRequestServiceImplTest {
         assertEquals(RequestStatus.OPEN, response.getStatus());
         assertEquals(departmentId, response.getDepartmentId());
         assertEquals(requesterId, response.getRequesterId());
-        assertNotNull(response.getSlaDeadline());
-        assertFalse(response.getIsSlaBreached());
+        verify(eventPublisher).publishEvent(argThat((Object event) ->
+                event instanceof ServiceRequestCreatedEvent(ServiceRequest request1)
+                        && request1.getRequester().getId().equals(requesterId)
+                        && request1.getDepartment().getId().equals(departmentId)));
     }
 
     @Test
@@ -119,6 +123,8 @@ class ServiceRequestServiceImplTest {
         ServiceRequest first = serviceRequest(UUID.randomUUID(), "First");
         ServiceRequest second = serviceRequest(UUID.randomUUID(), "Second");
         when(serviceRequestRepository.findAll()).thenReturn(List.of(first, second));
+        when(serviceRequestMapper.toResponse(first)).thenReturn(toResponse(first));
+        when(serviceRequestMapper.toResponse(second)).thenReturn(toResponse(second));
 
         List<ServiceRequestResponse> responses = serviceRequestService.findAll();
 
@@ -133,6 +139,7 @@ class ServiceRequestServiceImplTest {
         UUID requestId = UUID.randomUUID();
         ServiceRequest serviceRequest = serviceRequest(requestId, "Printer issue");
         when(serviceRequestRepository.findById(requestId)).thenReturn(Optional.of(serviceRequest));
+        when(serviceRequestMapper.toResponse(serviceRequest)).thenReturn(toResponse(serviceRequest));
 
         ServiceRequestResponse response = serviceRequestService.findById(requestId);
 
@@ -163,7 +170,6 @@ class ServiceRequestServiceImplTest {
         ServiceRequest existing = serviceRequest(requestId, "Old title");
         existing.setStatus(RequestStatus.OPEN);
         existing.setRequester(user(requesterId));
-        existing.setSlaDeadline(OffsetDateTime.now(ZoneOffset.UTC).plusHours(4));
 
         ServiceRequestUpsertRequest updateRequest = new ServiceRequestUpsertRequest();
         updateRequest.setTitle("New title");
@@ -173,15 +179,13 @@ class ServiceRequestServiceImplTest {
         updateRequest.setStatus(RequestStatus.RESOLVED);
 
         Department routedDepartment = department(departmentId, RequestCategory.FACILITIES);
-        SlaPolicy slaPolicy = slaPolicy(RequestCategory.FACILITIES, RequestPriority.CRITICAL);
-
         when(serviceRequestRepository.findById(requestId)).thenReturn(Optional.of(existing));
         when(userRepository.findById(assigneeId)).thenReturn(Optional.of(user(assigneeId)));
         when(departmentRepository.findByCategory(RequestCategory.FACILITIES)).thenReturn(Optional.of(routedDepartment));
-        when(slaPolicyRepository.findByCategoryAndPriority(RequestCategory.FACILITIES, RequestPriority.CRITICAL))
-                .thenReturn(Optional.of(slaPolicy));
         when(serviceRequestRepository.save(any(ServiceRequest.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        when(serviceRequestMapper.toResponse(any(ServiceRequest.class)))
+                .thenAnswer(invocation -> toResponse(invocation.getArgument(0)));
 
         ServiceRequestResponse response = serviceRequestService.update(requestId, updateRequest);
 
@@ -189,10 +193,13 @@ class ServiceRequestServiceImplTest {
         assertEquals(RequestCategory.FACILITIES, response.getCategory());
         assertEquals(RequestPriority.CRITICAL, response.getPriority());
         assertEquals(RequestStatus.RESOLVED, response.getStatus());
-        assertNotNull(response.getFirstResponseAt());
-        assertNotNull(response.getResolvedAt());
         assertEquals(departmentId, response.getDepartmentId());
         assertEquals(assigneeId, response.getAssignedToId());
+        verify(eventPublisher).publishEvent(argThat((Object event) ->
+                event instanceof ServiceRequestCreatedEvent createdEvent
+                        && createdEvent.request().getId().equals(requestId)
+                        && createdEvent.request().getCategory() == RequestCategory.FACILITIES
+                        && createdEvent.request().getPriority() == RequestPriority.CRITICAL));
     }
 
     @Test
@@ -239,6 +246,8 @@ class ServiceRequestServiceImplTest {
                 .thenReturn(Optional.of(department(UUID.randomUUID(), RequestCategory.HR_REQUEST)));
         when(serviceRequestRepository.save(any(ServiceRequest.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        when(serviceRequestMapper.toResponse(any(ServiceRequest.class)))
+                .thenAnswer(invocation -> toResponse(invocation.getArgument(0)));
 
         ServiceRequestResponse response = serviceRequestService.create(request);
 
@@ -261,16 +270,6 @@ class ServiceRequestServiceImplTest {
         return department;
     }
 
-    private SlaPolicy slaPolicy(RequestCategory category, RequestPriority priority) {
-        SlaPolicy policy = new SlaPolicy();
-        policy.setId(UUID.randomUUID());
-        policy.setCategory(category);
-        policy.setPriority(priority);
-        policy.setResolutionTimeHours(8);
-        policy.setResponseTimeHours(1);
-        return policy;
-    }
-
     private ServiceRequest serviceRequest(UUID id, String title) {
         ServiceRequest request = new ServiceRequest();
         request.setId(id);
@@ -281,5 +280,26 @@ class ServiceRequestServiceImplTest {
         request.setIsSlaBreached(Boolean.FALSE);
         request.setRequester(user(UUID.randomUUID()));
         return request;
+    }
+
+    private ServiceRequestResponse toResponse(ServiceRequest serviceRequest) {
+        return ServiceRequestResponse.builder()
+                .id(serviceRequest.getId())
+                .title(serviceRequest.getTitle())
+                .description(serviceRequest.getDescription())
+                .category(serviceRequest.getCategory())
+                .priority(serviceRequest.getPriority())
+                .status(serviceRequest.getStatus())
+                .departmentId(serviceRequest.getDepartment() == null ? null : serviceRequest.getDepartment().getId())
+                .assignedToId(serviceRequest.getAssignedTo() == null ? null : serviceRequest.getAssignedTo().getId())
+                .requesterId(serviceRequest.getRequester() == null ? null : serviceRequest.getRequester().getId())
+                .slaDeadline(serviceRequest.getSlaDeadline())
+                .firstResponseAt(serviceRequest.getFirstResponseAt())
+                .resolvedAt(serviceRequest.getResolvedAt())
+                .closedAt(serviceRequest.getClosedAt())
+                .isSlaBreached(serviceRequest.getIsSlaBreached())
+                .createdAt(serviceRequest.getCreatedAt())
+                .updatedAt(serviceRequest.getUpdatedAt())
+                .build();
     }
 }

--- a/backend/src/test/java/com/servicehub/service/impl/SlaServiceImplTest.java
+++ b/backend/src/test/java/com/servicehub/service/impl/SlaServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.servicehub.exception.SlaPolicyNotFoundException;
+import com.servicehub.event.ServiceRequestCreatedEvent;
 import com.servicehub.model.ServiceRequest;
 import com.servicehub.model.SlaPolicy;
 import com.servicehub.model.enums.RequestPriority;
@@ -144,6 +145,19 @@ class SlaServiceImplTest {
 
         assertNotNull(actualDeadline);
         verify(workingHoursCalculator).addBusinessHours(testRequest.getCreatedAt(), 168L);
+    }
+
+    @Test
+    @DisplayName("Should handle service request created event by setting SLA deadline")
+    void testHandleServiceRequestCreated() {
+        when(slaPolicyRepository.findByCategoryAndPriority(
+                RequestCategory.IT_SUPPORT, RequestPriority.CRITICAL))
+                .thenReturn(Optional.of(testPolicy));
+
+        slaService.handleServiceRequestCreated(new ServiceRequestCreatedEvent(testRequest));
+
+        assertNotNull(testRequest.getSlaDeadline());
+        verify(workingHoursCalculator).getNextWorkingHoursStart(testRequest.getCreatedAt());
     }
 
     @Test


### PR DESCRIPTION
This pull request refactors how SLA deadlines are handled for service requests. Instead of computing and setting SLA deadlines directly in the `ServiceRequestServiceImpl`, the logic is now triggered by publishing and handling a new `ServiceRequestCreatedEvent`. The mapping of entities to response DTOs is also centralized using a new `ServiceRequestMapper`. This change improves separation of concerns and makes the codebase more modular and testable.

**Event-driven SLA deadline calculation:**
- Introduced a new `ServiceRequestCreatedEvent` record to represent the creation of a service request.
- Refactored `ServiceRequestServiceImpl` to publish a `ServiceRequestCreatedEvent` after creating or updating a service request, instead of directly calculating the SLA deadline. [[1]](diffhunk://#diff-04cc54d44ed06e8438f6c54f15f6c3af097030bd4abef01b0c06c37a9392ddb2L51-R68) [[2]](diffhunk://#diff-04cc54d44ed06e8438f6c54f15f6c3af097030bd4abef01b0c06c37a9392ddb2L141-R145)
- Updated `SlaServiceImpl` to listen for `ServiceRequestCreatedEvent` and handle SLA deadline calculation and assignment.

**Mapping and DTO improvements:**
- Added a `ServiceRequestMapper` with explicit mappings to convert `ServiceRequest` entities to `ServiceRequestResponse` DTOs, and updated service methods to use this mapper. [[1]](diffhunk://#diff-1e730c4eefd1d206fbf22064d1d0515875262a2cd1f33f82ca49d2b0b0b5a062R15-R19) [[2]](diffhunk://#diff-04cc54d44ed06e8438f6c54f15f6c3af097030bd4abef01b0c06c37a9392ddb2L51-R68) [[3]](diffhunk://#diff-04cc54d44ed06e8438f6c54f15f6c3af097030bd4abef01b0c06c37a9392ddb2L85-R83) [[4]](diffhunk://#diff-04cc54d44ed06e8438f6c54f15f6c3af097030bd4abef01b0c06c37a9392ddb2L95-L103)

**Code cleanup and removal of direct SLA logic:**
- Removed direct SLA deadline calculation, status change metadata handling, and SLA breach flag logic from `ServiceRequestServiceImpl`. These responsibilities are now handled by event-driven mechanisms.

**Testing updates:**
- Updated tests to verify that events are published and that the new mapper is used for response conversion, removing reliance on direct SLA policy repository calls. [[1]](diffhunk://#diff-f07e6b2b0581c918a02c0e44410a9ad10f8f0f5968f436ad596b0ca9c7f3fe95L54-L71) [[2]](diffhunk://#diff-f07e6b2b0581c918a02c0e44410a9ad10f8f0f5968f436ad596b0ca9c7f3fe95L82-R98) [[3]](diffhunk://#diff-f07e6b2b0581c918a02c0e44410a9ad10f8f0f5968f436ad596b0ca9c7f3fe95R126-R127) [[4]](diffhunk://#diff-f07e6b2b0581c918a02c0e44410a9ad10f8f0f5968f436ad596b0ca9c7f3fe95R142) [[5]](diffhunk://#diff-f07e6b2b0581c918a02c0e44410a9ad10f8f0f5968f436ad596b0ca9c7f3fe95L176-R202)

These changes collectively improve modularity, maintainability, and testability of the service request and SLA management workflow.