### PR TITLE
chore(env): add example Google credentials to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ AIRFLOW_ADMIN_PASSWORD=airflow_pass
 LOG_LEVEL=INFO
 
 BACKEND_PORT=8080
+
+GOOGLE_CLIENT_ID=my-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=my-google-client-secret


### PR DESCRIPTION
## Summary

Adds the required Google credential environment variables to `.env.example`.

## Changes

* Added Google authentication environment variables to `.env.example`.
* Ensures developers know which variables are required for Google integration.

## Environment Variables Added

* `GOOGLE_CLIENT_ID`
* `GOOGLE_CLIENT_SECRET`

## Why

This helps developers quickly set up the project locally by clearly documenting the required Google credentials in the example environment file.

## Notes

* No functional code changes.
* Only updates the example environment configuration.
