### PR TITLE
fix(backend): align user departments and request workflow

### DIFF
--- a/backend/src/main/java/com/servicehub/config/DataSeeder.java
+++ b/backend/src/main/java/com/servicehub/config/DataSeeder.java
@@ -1,8 +1,13 @@
 package com.servicehub.config;
 
+import com.servicehub.model.Department;
 import com.servicehub.model.User;
+import com.servicehub.model.enums.RequestCategory;
 import com.servicehub.model.enums.Role;
+import com.servicehub.model.enums.UserDepartment;
+import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.UserRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -18,13 +23,34 @@ public class DataSeeder implements CommandLineRunner {
     private static final String ADMIN_PASSWORD = "password123";
     private static final String ADMIN_NAME     = "System Administrator";
 
+    private final DepartmentRepository departmentRepository;
     private final UserRepository  userRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     @SuppressWarnings("NullableProblems")
     public void run(String... args) {
+        seedDepartments();
         seedAdmin();
+    }
+
+    private void seedDepartments() {
+        seedDepartment(UserDepartment.IT);
+        seedDepartment(UserDepartment.HR);
+        seedDepartment(UserDepartment.FACILITIES);
+    }
+
+    private void seedDepartment(UserDepartment departmentDefinition) {
+        if (departmentRepository.findByNameIgnoreCase(departmentDefinition.getDisplayName()).isPresent()) {
+            return;
+        }
+
+        Department department = new Department();
+        department.setId(UUID.randomUUID());
+        department.setName(departmentDefinition.getDisplayName());
+        department.setCategory(departmentDefinition.getRequestCategory());
+        departmentRepository.save(department);
+        log.info("Department seeded: {}", departmentDefinition.getDisplayName());
     }
 
     private void seedAdmin() {
@@ -46,4 +72,3 @@ public class DataSeeder implements CommandLineRunner {
         log.info("Admin user created: {}", ADMIN_EMAIL);
     }
 }
-

--- a/backend/src/main/java/com/servicehub/controller/view/AdminWorkflowViewController.java
+++ b/backend/src/main/java/com/servicehub/controller/view/AdminWorkflowViewController.java
@@ -1,0 +1,31 @@
+package com.servicehub.controller.view;
+
+import com.servicehub.service.WorkflowService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/admin/requests")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class AdminWorkflowViewController {
+
+    private final WorkflowService workflowService;
+
+    @PostMapping("/{requestId}/transition")
+    public String transitionStatus(@PathVariable UUID requestId, RedirectAttributes redirectAttributes) {
+        try {
+            workflowService.transitionStatus(requestId);
+            redirectAttributes.addFlashAttribute("success", "Request status transitioned successfully.");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("error", "Could not transition request status: " + e.getMessage());
+        }
+        return "redirect:/admin/requests";
+    }
+}

--- a/backend/src/main/java/com/servicehub/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/servicehub/dto/RegisterRequest.java
@@ -2,6 +2,7 @@ package com.servicehub.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -18,5 +19,6 @@ public class RegisterRequest {
     @NotBlank
     private String confirmPassword;
     @NotBlank
+    @Pattern(regexp = "IT|HR|Facilities", message = "Department must be one of: IT, HR, Facilities")
     private String department;
 }

--- a/backend/src/main/java/com/servicehub/exception/DepartmentConfigurationException.java
+++ b/backend/src/main/java/com/servicehub/exception/DepartmentConfigurationException.java
@@ -1,0 +1,10 @@
+package com.servicehub.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DepartmentConfigurationException extends AuthException {
+
+    public DepartmentConfigurationException(String departmentName) {
+        super("Department is not configured: " + departmentName, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/main/java/com/servicehub/mapper/ServiceRequestMapper.java
+++ b/backend/src/main/java/com/servicehub/mapper/ServiceRequestMapper.java
@@ -13,8 +13,11 @@ import java.util.UUID;
 public interface ServiceRequestMapper {
 
     @Mapping(target = "departmentId", source = "department.id")
+    @Mapping(target = "departmentName", source = "department.name")
     @Mapping(target = "assignedToId", source = "assignedTo.id")
+    @Mapping(target = "assignedAgentName", source = "assignedTo.fullName")
     @Mapping(target = "requesterId", source = "requester.id")
+    @Mapping(target = "requesterName", source = "requester.fullName")
     ServiceRequestResponse toResponse(ServiceRequest serviceRequest);
 
     ServiceRequest toEntity(ServiceRequestResponse serviceRequestResponse);

--- a/backend/src/main/java/com/servicehub/model/User.java
+++ b/backend/src/main/java/com/servicehub/model/User.java
@@ -1,7 +1,9 @@
 package com.servicehub.model;
 
+import com.servicehub.model.enums.UserDepartment;
 import com.servicehub.model.enums.Role;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.hibernate.proxy.HibernateProxy;
 import org.jspecify.annotations.NonNull;
@@ -44,7 +46,12 @@ public class User implements UserDetails {
     private Role role;
 
     @Column(name = "department_name")
+    @Pattern(regexp = "IT|HR|Facilities", message = "Department must be one of: IT, HR, Facilities")
     private String department;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department departmentEntity;
 
     /** "local" | "google" */
     @Column(nullable = false)
@@ -60,7 +67,13 @@ public class User implements UserDetails {
 
     @PrePersist
     protected void onCreate() {
+        department = UserDepartment.normalize(department);
         createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        department = UserDepartment.normalize(department);
     }
 
     // ── UserDetails ──────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/servicehub/model/enums/UserDepartment.java
+++ b/backend/src/main/java/com/servicehub/model/enums/UserDepartment.java
@@ -1,0 +1,42 @@
+package com.servicehub.model.enums;
+
+import java.util.Arrays;
+
+public enum UserDepartment {
+    IT("IT", RequestCategory.IT_SUPPORT),
+    HR("HR", RequestCategory.HR_REQUEST),
+    FACILITIES("Facilities", RequestCategory.FACILITIES);
+
+    private final String displayName;
+    private final RequestCategory requestCategory;
+
+    UserDepartment(String displayName, RequestCategory requestCategory) {
+        this.displayName = displayName;
+        this.requestCategory = requestCategory;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public RequestCategory getRequestCategory() {
+        return requestCategory;
+    }
+
+    public static UserDepartment fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return Arrays.stream(values())
+                .filter(department -> department.displayName.equalsIgnoreCase(value)
+                        || department.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Department must be one of: IT, HR, Facilities"));
+    }
+
+    public static String normalize(String value) {
+        UserDepartment department = fromValue(value);
+        return department == null ? null : department.getDisplayName();
+    }
+}

--- a/backend/src/main/java/com/servicehub/repository/DepartmentRepository.java
+++ b/backend/src/main/java/com/servicehub/repository/DepartmentRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepartmentRepository extends JpaRepository<Department, UUID> {
     Optional<Department> findByCategory(RequestCategory category);
+
+    Optional<Department> findByNameIgnoreCase(String name);
 }

--- a/backend/src/main/java/com/servicehub/repository/UserRepository.java
+++ b/backend/src/main/java/com/servicehub/repository/UserRepository.java
@@ -35,4 +35,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
             ORDER BY u.createdAt DESC
             """)
     List<User> search(@Param("query") String query, @Param("role") Role role);
+
+    Optional<User> findFirstByRoleAndDepartmentIgnoreCaseOrderByCreatedAtAsc(Role role, String department);
 }

--- a/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
+++ b/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
@@ -21,6 +21,7 @@ public interface ServiceRequestService {
 
     ServiceRequestResponse update(UUID id, ServiceRequestUpsertRequest request);
 
+    void autoAssign(UUID id);
+
     void delete(UUID id);
 }
-

--- a/backend/src/main/java/com/servicehub/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/AuthServiceImpl.java
@@ -6,13 +6,17 @@ import com.servicehub.dto.AuthResponse;
 import com.servicehub.dto.RefreshTokenRequest;
 import com.servicehub.dto.RegisterRequest;
 import com.servicehub.exception.EmailAlreadyExistsException;
+import com.servicehub.exception.DepartmentConfigurationException;
 import com.servicehub.exception.InvalidCredentialsException;
 import com.servicehub.exception.InvalidRefreshTokenException;
 import com.servicehub.exception.PasswordMismatchException;
+import com.servicehub.model.Department;
 import com.servicehub.model.RefreshToken;
 import com.servicehub.model.TokenBlacklist;
 import com.servicehub.model.User;
 import com.servicehub.model.enums.Role;
+import com.servicehub.model.enums.UserDepartment;
+import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.RefreshTokenRepository;
 import com.servicehub.repository.TokenBlacklistRepository;
 import com.servicehub.repository.UserRepository;
@@ -43,6 +47,7 @@ public class AuthServiceImpl implements AuthService {
     private long refreshExpiration;
 
     private final UserRepository userRepository;
+    private final DepartmentRepository departmentRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenBlacklistRepository tokenBlacklistRepository;
     private final PasswordEncoder passwordEncoder;
@@ -61,12 +66,17 @@ public class AuthServiceImpl implements AuthService {
             throw new EmailAlreadyExistsException(request.getEmail());
         }
 
+        String departmentName = UserDepartment.normalize(request.getDepartment());
+        Department departmentEntity = departmentRepository.findByNameIgnoreCase(departmentName)
+                .orElseThrow(() -> new DepartmentConfigurationException(departmentName));
+
         User user = User.builder()
                 .email(request.getEmail())
                 .fullName(request.getFirstName() + " " + request.getLastName())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.USER)
-                .department(request.getDepartment())
+                .department(departmentName)
+                .departmentEntity(departmentEntity)
                 .provider("local")
                 .isActive(true)
                 .build();

--- a/backend/src/main/java/com/servicehub/service/impl/ServiceRequestServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/ServiceRequestServiceImpl.java
@@ -7,6 +7,7 @@ import com.servicehub.mapper.ServiceRequestMapper;
 import com.servicehub.model.Department;
 import com.servicehub.model.ServiceRequest;
 import com.servicehub.model.User;
+import com.servicehub.model.enums.Role;
 import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.exception.AccessDeniedException;
 import com.servicehub.exception.ResourceNotFoundException;
@@ -143,6 +144,20 @@ public class ServiceRequestServiceImpl implements ServiceRequestService {
             eventPublisher.publishEvent(new ServiceRequestCreatedEvent(savedRequest));
         }
         return serviceRequestMapper.toResponse(savedRequest);
+    }
+
+    @Override
+    @Transactional
+    public void autoAssign(UUID id) {
+        ServiceRequest serviceRequest = getRequestOrThrow(id);
+
+        if (serviceRequest.getAssignedTo() != null || serviceRequest.getDepartment() == null) {
+            return;
+        }
+
+        userRepository.findFirstByRoleAndDepartmentIgnoreCaseOrderByCreatedAtAsc(
+                        Role.AGENT, serviceRequest.getDepartment().getName())
+                .ifPresent(serviceRequest::setAssignedTo);
     }
 
     @Override

--- a/backend/src/main/java/com/servicehub/service/impl/WorkflowServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/WorkflowServiceImpl.java
@@ -8,6 +8,7 @@ import com.servicehub.exception.InvalidTransitionException;
 import com.servicehub.exception.ResourceNotFoundException;
 import com.servicehub.model.ServiceRequest;
 import com.servicehub.repository.ServiceRequestRepository;
+import com.servicehub.service.ServiceRequestService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class WorkflowServiceImpl implements WorkflowService {
     );
 
     private final ServiceRequestRepository serviceRequestRepository;
+    private final ServiceRequestService serviceRequestService;
 
     @Override
     @Transactional
@@ -50,6 +52,10 @@ public class WorkflowServiceImpl implements WorkflowService {
         }
 
         serviceRequest.setStatus(nextStatus);
+
+        if (nextStatus == RequestStatus.ASSIGNED) {
+            serviceRequestService.autoAssign(requestId);
+        }
 
         updateTimestamps(serviceRequest, nextStatus);
 

--- a/backend/src/main/resources/templates/admin/requests.html
+++ b/backend/src/main/resources/templates/admin/requests.html
@@ -147,10 +147,12 @@
               </td>
               <td class="p-3 whitespace-nowrap text-sm text-foreground" th:text="${#temporals.format(t.createdAt, 'dd MMM yyyy')}"></td>
               <td class="p-3 pe-5 whitespace-nowrap text-end text-sm font-medium">
-                <a th:href="@{/requests/{id}(id=${t.id})}"
-                   class="inline-flex items-center gap-x-2 text-sm font-semibold rounded-lg text-primary hover:text-primary-hover focus:outline-hidden focus:text-primary-focus disabled:opacity-50 disabled:pointer-events-none">
-                  View
-                </a>
+                <form th:action="@{/admin/requests/{id}/transition(id=${t.id})}" method="post" class="inline">
+                  <button type="submit"
+                          class="inline-flex items-center gap-x-2 text-sm font-semibold rounded-lg text-primary hover:text-primary-hover focus:outline-hidden focus:text-primary-focus disabled:opacity-50 disabled:pointer-events-none">
+                    Transition status
+                  </button>
+                </form>
               </td>
             </tr>
           </tbody>

--- a/backend/src/main/resources/templates/auth/register.html
+++ b/backend/src/main/resources/templates/auth/register.html
@@ -74,7 +74,7 @@
                         <option value="">Select department</option>
                         <option value="IT">IT</option>
                         <option value="HR">HR</option>
-                        <option value="FACILITIES">FACILITIES</option>
+                        <option value="Facilities">Facilities</option>
                     </select>
                 </div>
 

--- a/backend/src/test/java/com/servicehub/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/servicehub/service/auth/AuthServiceTest.java
@@ -9,10 +9,13 @@ import com.servicehub.exception.EmailAlreadyExistsException;
 import com.servicehub.exception.InvalidCredentialsException;
 import com.servicehub.exception.InvalidRefreshTokenException;
 import com.servicehub.exception.PasswordMismatchException;
+import com.servicehub.model.Department;
 import com.servicehub.model.RefreshToken;
 import com.servicehub.model.TokenBlacklist;
 import com.servicehub.model.User;
+import com.servicehub.model.enums.RequestCategory;
 import com.servicehub.model.enums.Role;
+import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.RefreshTokenRepository;
 import com.servicehub.repository.TokenBlacklistRepository;
 import com.servicehub.repository.UserRepository;
@@ -52,6 +55,7 @@ class AuthServiceTest {
 
 
     @Mock private UserRepository              userRepository;
+    @Mock private DepartmentRepository        departmentRepository;
     @Mock private RefreshTokenRepository      refreshTokenRepository;
     @Mock private TokenBlacklistRepository    tokenBlacklistRepository;
     @Mock private PasswordEncoder             passwordEncoder;
@@ -71,6 +75,7 @@ class AuthServiceTest {
 
     private User sampleUser;
     private RegisterRequest validRegisterRequest;
+    private Department itDepartment;
 
     @BeforeEach
     void setUp() {
@@ -86,6 +91,11 @@ class AuthServiceTest {
                 .provider("local")
                 .isActive(true)
                 .build();
+
+        itDepartment = new Department();
+        itDepartment.setId(UUID.randomUUID());
+        itDepartment.setName("IT");
+        itDepartment.setCategory(RequestCategory.IT_SUPPORT);
 
         validRegisterRequest = new RegisterRequest(
                 "John", "Doe", EMAIL, PASSWORD, PASSWORD, "IT");
@@ -103,6 +113,7 @@ class AuthServiceTest {
         @DisplayName("saves user and returns token pair on valid request")
         void register_validRequest_savesUserAndReturnsTokens() {
             when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+            when(departmentRepository.findByNameIgnoreCase("IT")).thenReturn(Optional.of(itDepartment));
             when(passwordEncoder.encode(PASSWORD)).thenReturn(ENCODED_PWD);
             when(userRepository.save(any(User.class))).thenReturn(sampleUser);
             when(jwtService.generateToken(any(User.class))).thenReturn(ACCESS_TOKEN);
@@ -122,6 +133,7 @@ class AuthServiceTest {
         @DisplayName("saves user with correct field values")
         void register_validRequest_userHasCorrectFields() {
             when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+            when(departmentRepository.findByNameIgnoreCase("IT")).thenReturn(Optional.of(itDepartment));
             when(passwordEncoder.encode(PASSWORD)).thenReturn(ENCODED_PWD);
             when(userRepository.save(any(User.class))).thenReturn(sampleUser);
             when(jwtService.generateToken(any())).thenReturn(ACCESS_TOKEN);
@@ -138,6 +150,7 @@ class AuthServiceTest {
             assertThat(saved.getPassword()).isEqualTo(ENCODED_PWD);
             assertThat(saved.getRole()).isEqualTo(Role.USER);
             assertThat(saved.getDepartment()).isEqualTo("IT");
+            assertThat(saved.getDepartmentEntity()).isEqualTo(itDepartment);
             assertThat(saved.getProvider()).isEqualTo("local");
             assertThat(saved.isActive()).isTrue();
         }
@@ -146,6 +159,7 @@ class AuthServiceTest {
         @DisplayName("saves a refresh token with correct expiry and not revoked")
         void register_validRequest_refreshTokenSavedCorrectly() {
             when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+            when(departmentRepository.findByNameIgnoreCase("IT")).thenReturn(Optional.of(itDepartment));
             when(passwordEncoder.encode(PASSWORD)).thenReturn(ENCODED_PWD);
             when(userRepository.save(any())).thenReturn(sampleUser);
             when(jwtService.generateToken(any())).thenReturn(ACCESS_TOKEN);
@@ -196,8 +210,13 @@ class AuthServiceTest {
         void register_fullNameConcatenated() {
             RegisterRequest req = new RegisterRequest(
                     "Alice", "Smith", EMAIL, PASSWORD, PASSWORD, "HR");
+            Department hrDepartment = new Department();
+            hrDepartment.setId(UUID.randomUUID());
+            hrDepartment.setName("HR");
+            hrDepartment.setCategory(RequestCategory.HR_REQUEST);
 
             when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+            when(departmentRepository.findByNameIgnoreCase("HR")).thenReturn(Optional.of(hrDepartment));
             when(passwordEncoder.encode(PASSWORD)).thenReturn(ENCODED_PWD);
             when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
             when(jwtService.generateToken(any())).thenReturn(ACCESS_TOKEN);

--- a/backend/src/test/java/com/servicehub/service/impl/ServiceRequestServiceImplTest.java
+++ b/backend/src/test/java/com/servicehub/service/impl/ServiceRequestServiceImplTest.java
@@ -21,6 +21,7 @@ import com.servicehub.model.User;
 import com.servicehub.model.enums.RequestCategory;
 import com.servicehub.model.enums.RequestPriority;
 import com.servicehub.model.enums.RequestStatus;
+import com.servicehub.model.enums.Role;
 import com.servicehub.repository.DepartmentRepository;
 import com.servicehub.repository.ServiceRequestRepository;
 import com.servicehub.repository.UserRepository;
@@ -231,6 +232,62 @@ class ServiceRequestServiceImplTest {
     }
 
     @Test
+    @DisplayName("autoAssign: assigns first matching agent in routed department")
+    void autoAssignShouldAssignFirstMatchingAgent() {
+        UUID requestId = UUID.randomUUID();
+        ServiceRequest request = serviceRequest(requestId, "Route me");
+        request.setDepartment(department(UUID.randomUUID(), RequestCategory.IT_SUPPORT));
+        request.getDepartment().setName("IT");
+
+        User agent = user(UUID.randomUUID());
+        agent.setRole(Role.AGENT);
+        agent.setDepartment("IT");
+
+        when(serviceRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        when(userRepository.findFirstByRoleAndDepartmentIgnoreCaseOrderByCreatedAtAsc(Role.AGENT, "IT"))
+                .thenReturn(Optional.of(agent));
+
+        serviceRequestService.autoAssign(requestId);
+
+        assertEquals(agent.getId(), request.getAssignedTo().getId());
+    }
+
+    @Test
+    @DisplayName("autoAssign: leaves request unchanged when already assigned")
+    void autoAssignShouldNotOverrideExistingAssignment() {
+        UUID requestId = UUID.randomUUID();
+        ServiceRequest request = serviceRequest(requestId, "Already assigned");
+        User existingAgent = user(UUID.randomUUID());
+        existingAgent.setRole(Role.AGENT);
+        request.setAssignedTo(existingAgent);
+        request.setDepartment(department(UUID.randomUUID(), RequestCategory.IT_SUPPORT));
+
+        when(serviceRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+        serviceRequestService.autoAssign(requestId);
+
+        assertEquals(existingAgent.getId(), request.getAssignedTo().getId());
+        verify(userRepository, never()).findFirstByRoleAndDepartmentIgnoreCaseOrderByCreatedAtAsc(any(), any());
+    }
+
+    @Test
+    @DisplayName("autoAssign: leaves request unassigned when no department agent exists")
+    void autoAssignShouldLeaveRequestUnassignedWhenNoMatchingAgentExists() {
+        UUID requestId = UUID.randomUUID();
+        ServiceRequest request = serviceRequest(requestId, "No agent available");
+        request.setDepartment(department(UUID.randomUUID(), RequestCategory.IT_SUPPORT));
+        request.getDepartment().setName("IT");
+
+        when(serviceRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        when(userRepository.findFirstByRoleAndDepartmentIgnoreCaseOrderByCreatedAtAsc(Role.AGENT, "IT"))
+                .thenReturn(Optional.empty());
+
+        serviceRequestService.autoAssign(requestId);
+
+        assertNull(request.getAssignedTo());
+    }
+
+    @Test
     @DisplayName("create: leaves firstResponseAt null when initial status is OPEN")
     void createShouldNotSetFirstResponseAtWhenStatusIsOpen() {
         UUID requesterId = UUID.randomUUID();
@@ -259,6 +316,7 @@ class ServiceRequestServiceImplTest {
         user.setId(id);
         user.setEmail("user@amalitech.com");
         user.setFullName("User");
+        user.setRole(Role.USER);
         return user;
     }
 

--- a/backend/src/test/java/com/servicehub/service/impl/WorkflowServiceImplTest.java
+++ b/backend/src/test/java/com/servicehub/service/impl/WorkflowServiceImplTest.java
@@ -3,6 +3,7 @@ package com.servicehub.service.impl;
 import com.servicehub.model.ServiceRequest;
 import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.repository.ServiceRequestRepository;
+import com.servicehub.service.ServiceRequestService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ class WorkflowServiceImplTest {
 
     @Mock
     private ServiceRequestRepository serviceRequestRepository;
+
+    @Mock
+    private ServiceRequestService serviceRequestService;
 
     private ServiceRequest testRequest;
 
@@ -53,6 +57,7 @@ class WorkflowServiceImplTest {
         assertEquals(RequestStatus.ASSIGNED, testRequest.getStatus());
         assertNotNull(testRequest.getFirstResponseAt());
         assertNotNull(testRequest.getUpdatedAt());
+        verify(serviceRequestService).autoAssign(testRequest.getId());
     }
 
     @Test
@@ -67,6 +72,7 @@ class WorkflowServiceImplTest {
 
         assertEquals(RequestStatus.IN_PROGRESS, testRequest.getStatus());
         assertEquals(firstResponse, testRequest.getFirstResponseAt());
+        verify(serviceRequestService, never()).autoAssign(any());
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces several enhancements to department handling and request workflow in the ServiceHub backend. The most notable changes are the introduction of a `UserDepartment` enum for standardized department management, improved validation and normalization for department data, automatic department seeding, and an auto-assignment feature for service requests. Additionally, a new admin workflow controller enables status transitions for requests via the UI.

**Department Management Improvements:**

* Added the `UserDepartment` enum to centralize department definitions and provide normalization and validation utilities.
* Updated department validation in `RegisterRequest`, `User`, and registration logic to use the `UserDepartment` enum, ensuring consistent department names and categories. [[1]](diffhunk://#diff-674c7dffb902fdc6e58bd3d9be6e99069794c3037d6c5f4fc7d7d89df5a64771R22) [[2]](diffhunk://#diff-5879a0d386662ae9f0470af410907d2cb282f2159d5641f761f3b7485e095caaR49-R55) [[3]](diffhunk://#diff-5879a0d386662ae9f0470af410907d2cb282f2159d5641f761f3b7485e095caaR70-R78) [[4]](diffhunk://#diff-306c908617145a1d0628573bb5327e1f26be886567d50c32c5f38e71a3a161ddR69-R79)
* Introduced automatic department seeding in `DataSeeder`, creating IT, HR, and Facilities departments if they do not exist.
* Added a custom `DepartmentConfigurationException` for cases where a department is not properly configured.
* Extended `DepartmentRepository` with a `findByNameIgnoreCase` method for robust department lookup.

**Service Request Workflow Enhancements:**

* Implemented an `autoAssign` method in `ServiceRequestServiceImpl` to automatically assign requests to the first available agent in the relevant department when transitioning to the ASSIGNED status.
* Modified the workflow transition logic to trigger auto-assignment when a request status changes to ASSIGNED.

**Admin Interface and Controller Updates:**

* Added `AdminWorkflowViewController` to handle request status transitions from the admin UI.
* Updated the admin requests template to replace the "View" link with a "Transition status" button, enabling admins to change request statuses directly.

**Data Mapping and Validation Improvements:**

* Enhanced `ServiceRequestMapper` to include department and agent names in the response DTO, improving data visibility in the UI.

**Repository and Test Adjustments:**

* Added a method to `UserRepository` for finding the first agent by department, supporting auto-assignment logic.
* Updated tests and mocks to accommodate department seeding and repository changes.

These changes collectively improve department consistency, automate request assignment, and streamline admin workflows.