### PR TITLE
chore: add DescribeInstanceInformation policy (#23)

### DIFF
--- a/ops-engine-room/infrastructure/staging-environment/modules/ci-cd/main.tf
+++ b/ops-engine-room/infrastructure/staging-environment/modules/ci-cd/main.tf
@@ -164,7 +164,8 @@ resource "aws_iam_policy" "github_ssm_deploy" {
         Action = [
           "ssm:GetCommandInvocation",
           "ssm:ListCommandInvocations",
-          "ssm:ListCommands"
+          "ssm:ListCommands",
+          "ssm:DescribeInstanceInformation"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
This pull request makes a minor update to the IAM policy for GitHub SSM deploy in the staging environment. The change grants additional permission to describe SSM instance information, which may be required for certain deployment or diagnostic workflows.

* IAM Policy Update:
  * Added the `"ssm:DescribeInstanceInformation"` permission to the `aws_iam_policy.github_ssm_deploy` resource in `main.tf`.