### PR TITLE
chore: refactor secret retrieval in CI workflow (#23)

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -271,16 +271,24 @@ jobs:
                     exit 1
                   fi
 
-                  DB_PASSWORD=$(aws secretsmanager get-secret-value \
+                  SECRET_JSON=$(aws secretsmanager get-secret-value \
                     --secret-id "$SECRET_ID" \
                     --query 'SecretString' \
-                    --output text | python3 -c 'import json,sys; print(json.load(sys.stdin)["password"])')
+                    --output text)
 
-                  echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
-                  echo "DB_PORT=${{ secrets.DB_PORT }}" >> .env
-                  echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
-                  echo "DB_USER=${{ secrets.DB_USER }}" >> .env
-                  echo "DB_PASSWORD=$DB_PASSWORD" >> .env
+                  DB_HOST=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["host"])' <<< "$SECRET_JSON")
+                  DB_PORT=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["port"])' <<< "$SECRET_JSON")
+                  DB_NAME=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["dbname"])' <<< "$SECRET_JSON")
+                  DB_USER=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["username"])' <<< "$SECRET_JSON")
+                  DB_PASSWORD=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["password"])' <<< "$SECRET_JSON")
+
+                  {
+                    echo "DB_HOST=$DB_HOST"
+                    echo "DB_PORT=$DB_PORT"
+                    echo "DB_NAME=$DB_NAME"
+                    echo "DB_USER=$DB_USER"
+                    echo "DB_PASSWORD=$DB_PASSWORD"
+                  } > .env
 
             - name: Archive data-engineering directory
               run: tar -czf data-engineering.tar.gz data-engineering/


### PR DESCRIPTION
This pull request updates how database credentials are retrieved and written to the `.env` file in the CI workflow. Instead of relying on GitHub secrets for individual values, the workflow now fetches all credentials from AWS Secrets Manager in a single JSON payload and parses each value using Python. This change streamlines secret management and reduces dependency on multiple GitHub secrets.

**CI Workflow Improvements:**

* All database credentials (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`) are now extracted from a single JSON secret fetched from AWS Secrets Manager, rather than from individual GitHub secrets.
* The credentials are parsed from the JSON and written to the `.env` file in one step, simplifying the environment setup process.