### PR TITLE
chore: update database strings to use URI-encoded (#23)

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -281,6 +281,8 @@ jobs:
                   DB_NAME=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["dbname"])' <<< "$SECRET_JSON")
                   DB_USER=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["username"])' <<< "$SECRET_JSON")
                   DB_PASSWORD=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["password"])' <<< "$SECRET_JSON")
+                  DB_USER_URI=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$DB_USER")
+                  DB_PASSWORD_URI=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$DB_PASSWORD")
 
                   AIRFLOW_DB="${{ secrets.AIRFLOW_DB }}"
                   AIRFLOW_WEB_PORT="${{ secrets.AIRFLOW_WEB_PORT }}"
@@ -302,6 +304,8 @@ jobs:
                     echo "DB_NAME=$DB_NAME"
                     echo "DB_USER=$DB_USER"
                     echo "DB_PASSWORD=$DB_PASSWORD"
+                    echo "DB_USER_URI=$DB_USER_URI"
+                    echo "DB_PASSWORD_URI=$DB_PASSWORD_URI"
                     echo "AIRFLOW_DB=$AIRFLOW_DB"
                     echo "AIRFLOW_WEB_PORT=$AIRFLOW_WEB_PORT"
                     echo "AIRFLOW_UID=$AIRFLOW_UID"

--- a/data-engineering/docker-compose.yml
+++ b/data-engineering/docker-compose.yml
@@ -9,8 +9,8 @@ x-airflow-common:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__CORE__AUTH_MANAGER: airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
-    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@postgres:${DB_PORT}/${AIRFLOW_DB}
-    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${DB_USER}:${DB_PASSWORD}@postgres:${DB_PORT}/${AIRFLOW_DB}
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${DB_USER_URI}:${DB_PASSWORD_URI}@postgres:${DB_PORT}/${AIRFLOW_DB}
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${DB_USER_URI}:${DB_PASSWORD_URI}@postgres:${DB_PORT}/${AIRFLOW_DB}
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ""
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"


### PR DESCRIPTION
This pull request improves the way database credentials are handled for Airflow by ensuring that the database username and password are properly URL-encoded before being used in connection strings. This prevents issues when credentials include special characters. The changes affect both the GitHub Actions workflow and the Airflow Docker Compose configuration.

Credential handling improvements:

* In the GitHub Actions workflow file `.github/workflows/ci-reusable.yml`, added steps to URL-encode the `DB_USER` and `DB_PASSWORD` values and store them as `DB_USER_URI` and `DB_PASSWORD_URI`. These are then output for use in subsequent steps. [[1]](diffhunk://#diff-63e803feb761c72e245ed6101be87d717419d951fb84f29d879bba00059db44bR284-R285) [[2]](diffhunk://#diff-63e803feb761c72e245ed6101be87d717419d951fb84f29d879bba00059db44bR307-R308)

Airflow configuration updates:

* Updated the Airflow Docker Compose environment in `data-engineering/docker-compose.yml` to use the URL-encoded `DB_USER_URI` and `DB_PASSWORD_URI` in the `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN` and `AIRFLOW__CELERY__RESULT_BACKEND` connection strings, replacing the previous use of unencoded credentials.