### PR TITLE
feat(deploy): increased wait logic with timeout and polling (#23)

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -362,10 +362,42 @@ jobs:
                     exit 1
                   fi
 
+                  TIMEOUT=900   # 15 minutes
+                  INTERVAL=15  # poll every 15 seconds
+
                   for INSTANCE_ID in $INSTANCE_IDS; do
-                    echo "Waiting for command $COMMAND_ID on instance $INSTANCE_ID"
-                    aws ssm wait command-executed \
-                      --command-id "$COMMAND_ID" \
-                      --instance-id "$INSTANCE_ID" \
-                      --region ${{ secrets.AWS_REGION }}
+                    echo "Waiting for command $COMMAND_ID on instance $INSTANCE_ID (timeout: ${TIMEOUT}s)"
+                    ELAPSED=0
+                    while true; do
+                      STATUS=$(aws ssm get-command-invocation \
+                        --command-id "$COMMAND_ID" \
+                        --instance-id "$INSTANCE_ID" \
+                        --region "${{ secrets.AWS_REGION }}" \
+                        --query 'Status' \
+                        --output text)
+
+                      echo "  [$ELAPSED s] Status: $STATUS"
+
+                      if [ "$STATUS" = "Success" ]; then
+                        echo "Command succeeded on $INSTANCE_ID"
+                        break
+                      elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+                        echo "Command failed on $INSTANCE_ID with status: $STATUS"
+                        aws ssm get-command-invocation \
+                          --command-id "$COMMAND_ID" \
+                          --instance-id "$INSTANCE_ID" \
+                          --region "${{ secrets.AWS_REGION }}" \
+                          --query '{StandardOutputContent:StandardOutputContent,StandardErrorContent:StandardErrorContent}' \
+                          --output json || true
+                        exit 1
+                      fi
+
+                      if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                        echo "Timed out after ${TIMEOUT}s waiting for command on $INSTANCE_ID"
+                        exit 1
+                      fi
+
+                      sleep "$INTERVAL"
+                      ELAPSED=$((ELAPSED + INTERVAL))
+                    done
                   done


### PR DESCRIPTION
This pull request improves the reliability and observability of the AWS SSM command execution step in the CI workflow by replacing the `aws ssm wait` command with a custom polling loop. This change allows for better handling of command statuses, configurable timeouts, and more detailed output in case of failures.

**Enhancements to AWS SSM command execution in CI:**

* Replaced the use of `aws ssm wait command-executed` with a custom polling loop, enabling explicit timeout control (15 minutes) and periodic status checks every 15 seconds.
* Improved failure handling by outputting both standard output and error content from failed commands, aiding in debugging.
* Added detailed logging of elapsed time and command status during polling for increased transparency in CI logs.