### PR TITLE
feat(ci): add separate workflows for Data Engineering (#23)

### DIFF
--- a/.github/workflows/ci-merge-data.yml
+++ b/.github/workflows/ci-merge-data.yml
@@ -1,0 +1,28 @@
+name: Merge CI (Data Engineering)
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - data-engineering/**
+            - .github/workflows/**
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    data:
+        name: Data Engineering merge checks + deploy
+        uses: ./.github/workflows/ci-reusable.yml
+        with:
+            run_checkstyle: false
+            run_tests: false
+            build_image: false
+            push_image: false
+            run_data_tests: true
+            run_checkov: false
+            run_trivy: false
+            run_sbom: false
+            deploy_dags: true
+        secrets: inherit

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -5,7 +5,6 @@ on:
         branches: [main]
         paths:
             - backend/**
-            - data-engineering/**
             - .github/workflows/**
 
 permissions:
@@ -21,9 +20,9 @@ jobs:
             run_tests: true
             build_image: true
             push_image: true
-            run_data_tests: true
+            run_data_tests: false
             run_checkov: true
             run_trivy: false
             run_sbom: true
-            deploy_dags: true
+            deploy_dags: false
         secrets: inherit

--- a/.github/workflows/ci-pr-data.yml
+++ b/.github/workflows/ci-pr-data.yml
@@ -1,0 +1,32 @@
+name: PR CI (Data Engineering)
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - data-engineering/**
+            - .github/workflows/**
+
+concurrency:
+    group: pr-data-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    data:
+        name: Data Engineering PR checks
+        uses: ./.github/workflows/ci-reusable.yml
+        with:
+            run_checkstyle: false
+            run_tests: false
+            build_image: false
+            push_image: false
+            run_data_tests: true
+            run_checkov: false
+            run_trivy: false
+            run_sbom: false
+            deploy_dags: false
+        secrets: inherit

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,6 @@ on:
         branches: [main]
         paths:
             - backend/**
-            - data-engineering/**
             - .github/workflows/**
 
 concurrency:
@@ -24,7 +23,7 @@ jobs:
             run_checkstyle: true
             run_tests: true
             build_image: false
-            run_data_tests: true
+            run_data_tests: false
             run_checkov: true            
             run_trivy: false
             run_sbom: true


### PR DESCRIPTION
This pull request restructures the CI workflows to provide dedicated pipelines for the `data-engineering` directory, separating them from the main backend workflows. The changes introduce new workflows specifically for data engineering and update existing workflows to exclude data engineering tasks, ensuring clearer separation of concerns and more targeted CI runs.

**Workflow separation and new data engineering pipelines:**

* Added a new workflow `.github/workflows/ci-pr-data.yml` for running CI checks on pull requests that affect the `data-engineering` directory. This workflow runs only data-related tests and skips backend-specific checks.
* Added a new workflow `.github/workflows/ci-merge-data.yml` for running merge checks and deploying DAGs when changes are pushed to the `main` branch in the `data-engineering` directory.

**Updates to existing backend workflows:**

* Modified `.github/workflows/ci-pr.yml` and `.github/workflows/ci-merge.yml` to exclude the `data-engineering` directory from their triggers, so they no longer run for changes only affecting data engineering. [[1]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L8) [[2]](diffhunk://#diff-a5d19118b913bff0f8969d4c2f2f113389cd8406d98028a2f72e7a9ea5ec5c70L8)
* Updated the backend workflows to disable data engineering-specific steps (`run_data_tests` and `deploy_dags`) since these are now handled by the new dedicated workflows. [[1]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L27-R26) [[2]](diffhunk://#diff-a5d19118b913bff0f8969d4c2f2f113389cd8406d98028a2f72e7a9ea5ec5c70L24-R27)