### PR TITLE
Feature/extra seed data

### DIFF
--- a/backend/src/main/java/com/servicehub/config/DataSeeder.java
+++ b/backend/src/main/java/com/servicehub/config/DataSeeder.java
@@ -23,7 +23,7 @@ public class DataSeeder implements CommandLineRunner {
     private static final String ADMIN_PASSWORD = "password123";
     private static final String ADMIN_NAME     = "System Administrator";
     private static final String AGENT_PASSWORD = "password123";
-    
+
     private static final List<AgentSeed> AGENT_SEEDS = List.of(
             new AgentSeed("ama.boateng@amalitech.com", "Ama Boateng", UserDepartment.IT),
             new AgentSeed("kwame.asare@amalitech.com", "Kwame Asare", UserDepartment.IT),
@@ -34,20 +34,20 @@ public class DataSeeder implements CommandLineRunner {
             new AgentSeed("akosua.darko@amalitech.com", "Akosua Darko", UserDepartment.HR),
             new AgentSeed("nana.quaye@amalitech.com", "Nana Quaye", UserDepartment.FACILITIES),
             new AgentSeed("adwoa.sarpong@amalitech.com", "Adwoa Sarpong", UserDepartment.FACILITIES),
-            new AgentSeed("kofi.bonsu@amalitech.com", "Kofi Bonsu", UserDepartment.FACILITIES)); 
-            
+            new AgentSeed("kofi.bonsu@amalitech.com", "Kofi Bonsu", UserDepartment.FACILITIES));
+
     private static final String USER_PASSWORD  = "password123";
     private static final List<SeedUser> REGULAR_USERS = List.of(
-            new SeedUser("Daniel Agyeman", "daniel.agyeman@amalitech.com"),
-            new SeedUser("Priscilla Tetteh", "priscilla.tetteh@amalitech.com"),
-            new SeedUser("Samuel Frimpong", "samuel.frimpong@amalitech.com"),
-            new SeedUser("Belinda Kwarteng", "belinda.kwarteng@amalitech.com"),
-            new SeedUser("Emmanuel Sarpong", "emmanuel.sarpong@amalitech.com"),
-            new SeedUser("Gloria Darko", "gloria.darko@amalitech.com"),
-            new SeedUser("Richard Nartey", "richard.nartey@amalitech.com"),
-            new SeedUser("Doreen Badu", "doreen.badu@amalitech.com"),
-            new SeedUser("Michael Koranteng", "michael.koranteng@amalitech.com"),
-            new SeedUser("Patience Aidoo", "patience.aidoo@amalitech.com")
+            new SeedUser("Daniel Agyeman", "daniel.agyeman@amalitech.com", UserDepartment.IT),
+            new SeedUser("Priscilla Tetteh", "priscilla.tetteh@amalitech.com", UserDepartment.IT),
+            new SeedUser("Samuel Frimpong", "samuel.frimpong@amalitech.com", UserDepartment.IT),
+            new SeedUser("Belinda Kwarteng", "belinda.kwarteng@amalitech.com", UserDepartment.IT),
+            new SeedUser("Emmanuel Sarpong", "emmanuel.sarpong@amalitech.com", UserDepartment.HR),
+            new SeedUser("Gloria Darko", "gloria.darko@amalitech.com", UserDepartment.HR),
+            new SeedUser("Richard Nartey", "richard.nartey@amalitech.com", UserDepartment.HR),
+            new SeedUser("Doreen Badu", "doreen.badu@amalitech.com", UserDepartment.FACILITIES),
+            new SeedUser("Michael Koranteng", "michael.koranteng@amalitech.com", UserDepartment.FACILITIES),
+            new SeedUser("Patience Aidoo", "patience.aidoo@amalitech.com", UserDepartment.FACILITIES)
     );
 
     private final DepartmentRepository departmentRepository;
@@ -59,6 +59,7 @@ public class DataSeeder implements CommandLineRunner {
     public void run(String... args) {
         seedDepartments();
         seedAdmin();
+        seedRegularUsers();
         seedAgents();
     }
 
@@ -79,7 +80,6 @@ public class DataSeeder implements CommandLineRunner {
         department.setCategory(departmentDefinition.getRequestCategory());
         departmentRepository.save(department);
         log.info("Department seeded: {}", departmentDefinition.getDisplayName());
-        seedRegularUsers();
     }
 
     private void seedAdmin() {
@@ -132,7 +132,7 @@ public class DataSeeder implements CommandLineRunner {
 
     private record AgentSeed(String email, String fullName, UserDepartment department) {
     }
-    
+
     private void seedRegularUsers() {
         for (SeedUser seedUser : REGULAR_USERS) {
             String email = seedUser.email();
@@ -142,11 +142,17 @@ public class DataSeeder implements CommandLineRunner {
                 continue;
             }
 
+            Department department = departmentRepository.findByNameIgnoreCase(seedUser.department().getDisplayName())
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Department not found for regular user seed: " + seedUser.department().getDisplayName()));
+
             User user = User.builder()
                     .email(email)
                     .fullName(seedUser.fullName())
                     .password(passwordEncoder.encode(USER_PASSWORD))
                     .role(Role.USER)
+                    .department(seedUser.department().getDisplayName())
+                    .departmentEntity(department)
                     .provider("local")
                     .isActive(true)
                     .build();
@@ -156,5 +162,5 @@ public class DataSeeder implements CommandLineRunner {
         }
     }
 
-    private record SeedUser(String fullName, String email) {}
+    private record SeedUser(String fullName, String email, UserDepartment department) {}
 }

--- a/backend/src/main/java/com/servicehub/service/SlaScheduler.java
+++ b/backend/src/main/java/com/servicehub/service/SlaScheduler.java
@@ -11,7 +11,7 @@ public class SlaScheduler {
 
     private final SlaServiceImpl slaBreachService;
 
-    @Scheduled(fixedRate = 1000)
+    @Scheduled(fixedRate = 120000)
     public void checkSlaBreaches() {
         slaBreachService.detectAndUpdateBreachStatus();
     }


### PR DESCRIPTION
This pull request enhances the data seeding process and improves the performance of scheduled SLA checks. The main updates include adding seeding logic for regular users and adjusting the frequency of SLA breach checks.

**Data seeding improvements:**

* Added a new `SeedUser` record and a `REGULAR_USERS` list in `DataSeeder.java` to seed regular (non-agent) users into the database, including their department associations. Implemented the `seedRegularUsers()` method to handle this process and integrated it into the application startup routine. [[1]](diffhunk://#diff-09cad5ec3d83ffdb40f355550ae110d99fd3cb671f49d02055b2ac703af915d4L36-R50) [[2]](diffhunk://#diff-09cad5ec3d83ffdb40f355550ae110d99fd3cb671f49d02055b2ac703af915d4R135-R165) [[3]](diffhunk://#diff-09cad5ec3d83ffdb40f355550ae110d99fd3cb671f49d02055b2ac703af915d4R62)

**Scheduler configuration:**

* Increased the interval for the `checkSlaBreaches` scheduled task in `SlaScheduler.java` from every 1 second to every 2 minutes, reducing unnecessary load on the system.