### PR TITLE
feat(frontend): add link to sla breaches (#1)

### DIFF
--- a/backend/src/main/java/com/servicehub/controller/view/AdminController.java
+++ b/backend/src/main/java/com/servicehub/controller/view/AdminController.java
@@ -1,6 +1,7 @@
 package com.servicehub.controller.view;
 
 import com.servicehub.model.User;
+import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.model.enums.Role;
 import com.servicehub.service.ServiceRequestService;
 import com.servicehub.service.UserService;
@@ -11,12 +12,16 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.List;
 import java.util.UUID;
 
 @Controller
 @RequestMapping("/admin")
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
+
+    private static final List<RequestStatus> DONE_STATUSES =
+        List.of(RequestStatus.RESOLVED, RequestStatus.CLOSED);
 
     private UserService userService;
     private ServiceRequestService serviceRequestService;
@@ -50,9 +55,20 @@ public class AdminController {
                               @AuthenticationPrincipal User principal,
                               @RequestParam(required = false) String q,
                               @RequestParam(required = false) String status,
-                              @RequestParam(required = false) String category) {
+                              @RequestParam(required = false) String category,
+                              @RequestParam(defaultValue = "false") boolean breached) {
         addCommonAttributes(model, principal);
-        model.addAttribute("allTickets", serviceRequestService.findAll());
+
+        var tickets = serviceRequestService.findAll();
+        if (breached) {
+            tickets = tickets.stream()
+                    .filter(t -> Boolean.TRUE.equals(t.getIsSlaBreached()))
+                    .filter(t -> !DONE_STATUSES.contains(t.getStatus()))
+                    .toList();
+        }
+
+        model.addAttribute("allTickets", tickets);
+        model.addAttribute("breachedOnly", breached);
         return "admin/requests";
     }
 

--- a/backend/src/main/java/com/servicehub/controller/view/AdminWorkflowViewController.java
+++ b/backend/src/main/java/com/servicehub/controller/view/AdminWorkflowViewController.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -19,13 +20,17 @@ public class AdminWorkflowViewController {
     private final WorkflowService workflowService;
 
     @PostMapping("/{requestId}/transition")
-    public String transitionStatus(@PathVariable UUID requestId, RedirectAttributes redirectAttributes) {
+    public String transitionStatus(@PathVariable UUID requestId,
+                                   @RequestParam(defaultValue = "false") boolean redirectToBreaches,
+                                   RedirectAttributes redirectAttributes) {
         try {
             workflowService.transitionStatus(requestId);
             redirectAttributes.addFlashAttribute("success", "Request status transitioned successfully.");
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("error", "Could not transition request status: " + e.getMessage());
         }
-        return "redirect:/admin/requests";
+        return redirectToBreaches
+                ? "redirect:/admin/requests?breached=true"
+                : "redirect:/admin/requests";
     }
 }

--- a/backend/src/main/resources/templates/admin/requests.html
+++ b/backend/src/main/resources/templates/admin/requests.html
@@ -1,12 +1,24 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{components/layout :: page(~{::content})}">
-<head><title>All Requests</title></head>
+<head>
+  <title th:text="${breachedOnly} ? 'Active Breaches' : 'All Requests'">All Requests</title>
+</head>
 <body>
   <div th:fragment="content">
 
     <div class="mb-6">
-      <h2 class="text-2xl font-semibold text-foreground">All Requests</h2>
-      <p class="text-sm text-muted-foreground-1">Every service request across all users and departments.</p>
+      <h2 class="text-2xl font-semibold text-foreground" th:text="${breachedOnly} ? 'Active Breaches' : 'All Requests'">All Requests</h2>
+      <p class="text-sm text-muted-foreground-1"
+         th:text="${breachedOnly} ? 'Only currently breached and still-open requests.' : 'Every service request across all users and departments.'">
+        Every service request across all users and departments.
+      </p>
+    </div>
+
+    <div th:if="${breachedOnly}" class="flex items-center justify-between gap-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-5">
+      <span>Showing live active breaches from the dashboard alert.</span>
+      <a th:href="@{/admin/requests}" class="inline-flex items-center px-3 py-1.5 rounded-lg bg-white border border-red-200 text-red-700 hover:bg-red-100 transition-colors">
+        View all requests
+      </a>
     </div>
 
     <div th:if="${success}" class="flex items-center gap-3 bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3 mb-5">
@@ -24,7 +36,7 @@
         <svg class="size-10 text-muted-foreground-2 opacity-30 mb-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/>
         </svg>
-        <p class="text-sm text-muted-foreground-1">No requests found.</p>
+        <p class="text-sm text-muted-foreground-1" th:text="${breachedOnly} ? 'No active breaches found.' : 'No requests found.'">No requests found.</p>
       </div>
     </div>
 
@@ -33,7 +45,7 @@
          class="bg-white border border-card-line rounded-xl shadow-sm p-4 sm:p-5 flex flex-col --prevent-on-load-init"
          data-request-table
          data-priority-column-index="3"
-         data-status-column-index="5"
+         data-status-column-index="7"
          data-hs-datatable='{
            "pageLength": 10,
            "pagingOptions": {
@@ -121,7 +133,13 @@
                 <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1">Priority</div>
               </th>
               <th scope="col" class="py-1 text-start font-normal">
-                <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1">Assigned To</div>
+                <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1 whitespace-nowrap">Assigned To</div>
+              </th>
+              <th scope="col" class="py-1 text-start font-normal">
+                <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1">DEADLINE</div>
+              </th>
+              <th scope="col" class="py-1 text-start font-normal">
+                <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1">Breached</div>
               </th>
               <th scope="col" class="py-1 text-start font-normal">
                 <div class="py-1 px-3 inline-flex items-center text-sm text-muted-foreground-1">Status</div>
@@ -142,12 +160,19 @@
                 <th:block th:replace="~{components/request-badges :: priorityBadge(${t.priority})}"></th:block>
               </td>
               <td class="p-3 whitespace-nowrap text-sm text-foreground" th:text="${t.assignedAgentName} ?: '—'"></td>
+              <td class="p-3 whitespace-nowrap text-sm text-foreground"
+                  th:text="${t.slaDeadline != null} ? ${#temporals.format(t.slaDeadline, 'dd MMM yyyy HH:mm')} : '—'"></td>
+              <td class="p-3 whitespace-nowrap text-sm text-foreground">
+                <span th:if="${t.isSlaBreached == true}" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Yes</span>
+                <span th:if="${t.isSlaBreached != true}" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-700">No</span>
+              </td>
               <td class="p-3 whitespace-nowrap text-sm text-foreground">
                 <th:block th:replace="~{components/request-badges :: statusBadge(${t.status})}"></th:block>
               </td>
               <td class="p-3 whitespace-nowrap text-sm text-foreground" th:text="${#temporals.format(t.createdAt, 'dd MMM yyyy')}"></td>
               <td class="p-3 pe-5 whitespace-nowrap text-end text-sm font-medium">
                 <form th:action="@{/admin/requests/{id}/transition(id=${t.id})}" method="post" class="inline">
+                  <input th:if="${breachedOnly}" type="hidden" name="redirectToBreaches" value="true" />
                   <button type="submit"
                           class="inline-flex items-center gap-x-2 px-3 py-1.5 text-sm font-semibold rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-hidden focus:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none transition">
                     Transition

--- a/backend/src/main/resources/templates/dashboard/admin.html
+++ b/backend/src/main/resources/templates/dashboard/admin.html
@@ -14,14 +14,16 @@
         <h2 class="text-2xl font-semibold text-foreground">Operations Dashboard</h2>
         <p class="text-sm text-muted-foreground-1">Analytics refreshed nightly · live breach data</p>
       </div>
-      <div th:if="${activeBreaches > 0}"
-           class="flex items-center gap-2 bg-red-600 text-white text-sm font-semibold px-4 py-2 rounded-full animate-pulse">
+      <a th:if="${activeBreaches > 0}"
+         th:href="@{/admin/requests(breached=true)}"
+         class="flex items-center gap-2 bg-red-600 text-white text-sm font-semibold px-4 py-2 rounded-full animate-pulse hover:bg-red-700 transition-colors"
+         title="View active breached requests">
         <svg class="size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/>
         </svg>
         <span th:text="${activeBreaches}"></span>
         Active Breach<span th:if="${activeBreaches > 1}">es</span>
-      </div>
+      </a>
     </div>
 
     <!-- Tab Navigation -->


### PR DESCRIPTION
This pull request introduces a new "Active Breaches" view for admin users, allowing them to easily filter, view, and manage service requests that have breached their SLA and are still open. The dashboard breach alert now links directly to this filtered view, and the admin requests table and workflow are updated to support this functionality.

**Admin "Active Breaches" View and Filtering:**

* Added a `breached` query parameter to the admin requests route and controller, enabling filtering of service requests to show only those that have breached their SLA and are not resolved or closed. (`AdminController.java`, `requests.html`) [[1]](diffhunk://#diff-7dd0abe6b6f557a21e9db03b8adf1359301265ac3a871b111381f5ca3d5c4ba7R15-R25) [[2]](diffhunk://#diff-7dd0abe6b6f557a21e9db03b8adf1359301265ac3a871b111381f5ca3d5c4ba7L53-R71) [[3]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3L3-R21)
* Updated the admin requests template to dynamically update titles, descriptions, and empty states when viewing breaches, and to display a prominent banner with a link to view all requests. (`requests.html`) [[1]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3L3-R21) [[2]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3L27-R39)
* Enhanced the requests table with new columns for SLA deadline and breach status, and updated the status column index for the datatable. (`requests.html`) [[1]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3L36-R48) [[2]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3L124-R142) [[3]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3R163-R175)

**Dashboard Integration:**

* Modified the admin dashboard's active breaches alert to be a clickable link that takes the user directly to the filtered "Active Breaches" view. (`dashboard/admin.html`)

**Workflow Improvements:**

* Updated the admin workflow transition handler to support redirecting back to the breaches view when transitioning a breached request, preserving the filtered context for the admin. (`AdminWorkflowViewController.java`, `requests.html`) [[1]](diffhunk://#diff-899025295447f0c523f6f9d88cae7ec7097e7ce4caa2082283f65943e5a2722bR11) [[2]](diffhunk://#diff-899025295447f0c523f6f9d88cae7ec7097e7ce4caa2082283f65943e5a2722bL22-R34) [[3]](diffhunk://#diff-f31e47f0d83ef7c78d40e2a985b1593bce3cafa38cc240736e7426d9abd27cc3R163-R175)