### PR TITLE
fix(backend): send email notification asynchronously on requests stat…

### DIFF
--- a/backend/src/main/java/com/servicehub/ServiceHubApplication.java
+++ b/backend/src/main/java/com/servicehub/ServiceHubApplication.java
@@ -2,9 +2,11 @@ package com.servicehub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableAsync
 @EnableScheduling
 public class ServiceHubApplication {
 

--- a/backend/src/main/java/com/servicehub/event/StatusTransitionEvent.java
+++ b/backend/src/main/java/com/servicehub/event/StatusTransitionEvent.java
@@ -1,7 +1,6 @@
 package com.servicehub.event;
 
-import com.servicehub.model.ServiceRequest;
 import com.servicehub.model.enums.RequestStatus;
 
-public record StatusTransitionEvent(ServiceRequest request) {
+public record StatusTransitionEvent(String requesterEmail, String requestTitle, RequestStatus status) {
 }

--- a/backend/src/main/java/com/servicehub/service/impl/WorkflowServiceImpl.java
+++ b/backend/src/main/java/com/servicehub/service/impl/WorkflowServiceImpl.java
@@ -14,6 +14,7 @@ import com.servicehub.service.Notification;
 import com.servicehub.service.ServiceRequestService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,12 +43,13 @@ public class WorkflowServiceImpl implements WorkflowService {
     private final Notification emailService;
     private final ServiceRequestService serviceRequestService;
 
+    @Async
     @EventListener
     void handleStatusTransitionEvent(StatusTransitionEvent event) {
         emailService.sendStatusUpdate(
-                event.request().getRequester().getEmail(),
-                event.request().getTitle(),
-                event.request().getStatus()
+                event.requesterEmail(),
+                event.requestTitle(),
+                event.status()
         );
     }
 
@@ -79,7 +81,11 @@ public class WorkflowServiceImpl implements WorkflowService {
 
         updateTimestamps(serviceRequest, nextStatus);
 
-        publisher.publishEvent(new StatusTransitionEvent(serviceRequest));
+        publisher.publishEvent(new StatusTransitionEvent(
+                serviceRequest.getRequester().getEmail(),
+                serviceRequest.getTitle(),
+                serviceRequest.getStatus()
+        ));
 
         serviceRequest.setUpdatedAt(OffsetDateTime.now());
 

--- a/backend/src/test/java/com/servicehub/service/impl/WorkflowServiceImplTest.java
+++ b/backend/src/test/java/com/servicehub/service/impl/WorkflowServiceImplTest.java
@@ -64,10 +64,17 @@ class WorkflowServiceImplTest {
         assignedAgent.setRole(Role.AGENT);
         assignedAgent.setDepartment("IT");
 
+        User requester = new User();
+        requester.setId(UUID.randomUUID());
+        requester.setEmail("requester@example.com");
+        requester.setFullName("Requester User");
+
         testRequest = new ServiceRequest();
         testRequest.setId(id);
+        testRequest.setTitle("Printer issue");
         testRequest.setStatus(RequestStatus.OPEN);
         testRequest.setDepartment(itDepartment);
+        testRequest.setRequester(requester);
         testRequest.setCreatedAt(OffsetDateTime.now());
         testRequest.setUpdatedAt(OffsetDateTime.now());
 


### PR DESCRIPTION
This pull request introduces asynchronous handling for status transition events and refactors how status transition data is passed throughout the workflow. The changes improve the scalability of event processing and simplify event data by passing only the necessary fields instead of entire objects.

**Asynchronous event handling:**

* Enabled asynchronous processing in the application by adding the `@EnableAsync` annotation to `ServiceHubApplication` and marking the event listener in `WorkflowServiceImpl` with `@Async`. This allows status transition events to be handled in parallel, improving responsiveness. [[1]](diffhunk://#diff-02e60f1337aca4525f34ea4aa2501bf2f8e92fc0ecc1c90d28f93864f72e642bR5-R9) [[2]](diffhunk://#diff-4572b8a4b583bd75f5845e36757ab79e95d6f8a68ccc7695e4af1211ab955bbcR17) [[3]](diffhunk://#diff-4572b8a4b583bd75f5845e36757ab79e95d6f8a68ccc7695e4af1211ab955bbcR46-R52)

**Event data refactoring:**

* Changed the `StatusTransitionEvent` to carry only the requester's email, request title, and status instead of the whole `ServiceRequest` object. Updated event publishing and handling logic in `WorkflowServiceImpl` to reflect this change, reducing coupling and improving clarity. [[1]](diffhunk://#diff-fe003125b84dacd9b6469aa896b442dbd4eaf43d700b6ced8d0b2a3bf8d85646L3-R5) [[2]](diffhunk://#diff-4572b8a4b583bd75f5845e36757ab79e95d6f8a68ccc7695e4af1211ab955bbcR46-R52) [[3]](diffhunk://#diff-4572b8a4b583bd75f5845e36757ab79e95d6f8a68ccc7695e4af1211ab955bbcL82-R88)

**Test improvements:**

* Updated the test setup in `WorkflowServiceImplTest` to include a requester user and request title for the new event structure.